### PR TITLE
Fix MIT Scheme manual URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section).
 * [Dybvig, R. Kent, Robert Hieb, and Carl Bruggeman. "Syntactic abstraction in Scheme."
 _Lisp and symbolic computation_ 5.4 (1993): 295-326.
 ](https://www.cs.indiana.edu/~dyb/pubs/LaSC-5-4-pp295-326.pdf)
-* https://www.gnu.org/software/mit-scheme/documentation/mit-scheme-ref/Syntactic-Closures.html#Syntactic-Closures
+* https://www.gnu.org/software/mit-scheme/documentation/stable/mit-scheme-ref.html#Syntactic-Closures


### PR DESCRIPTION
The previous URL was leading to a 404 page.